### PR TITLE
Make single-instance mode work under linux.

### DIFF
--- a/src/main/java/com/evilcorp/util/Shortcuts.java
+++ b/src/main/java/com/evilcorp/util/Shortcuts.java
@@ -2,7 +2,10 @@ package com.evilcorp.util;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 public class Shortcuts {
     public static void sleep(long millis) {
@@ -32,5 +35,15 @@ public class Shortcuts {
             hexString.append(hex);
         }
         return hexString.toString();
+    }
+
+    public static void createDirectoryIfNotExists(Path directory) {
+        try {
+            if (Files.notExists(directory)) {
+                Files.createDirectory(directory);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
Fixes runmpv/issues/1

The problem was that controlling domain socket was placed in video file
directory. So, when user tried to open a file from different directory,
runmpv couldn't find existing controlling socket.

All controlling domain sockets are placed in XDG_RUNTIME_DIR now.
If XDG_RUNTIME_DIR/runmpv is not defined, then they are placed in /tmp/runmpv

Domain socket name for single-instance openMode is fixed.
Domain socket name for instance-per-directory openMode is SHA-3 of video file path.