### PR TITLE
Support comments in runmpv.properties

### DIFF
--- a/src/main/java/com/evilcorp/settings/TextFileSettings.java
+++ b/src/main/java/com/evilcorp/settings/TextFileSettings.java
@@ -33,6 +33,7 @@ public class TextFileSettings implements SoftSettings {
         final InputStreamReader inputStreamReader = new InputStreamReader(source, StandardCharsets.UTF_8);
         final BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
         settings = bufferedReader.lines()
+            .filter(l -> !l.trim().startsWith("#"))
             .map(l -> l.split("="))
             .filter(s -> s.length == 2)
             .filter(s -> !s[0].isBlank())

--- a/src/test/java/com/evilcorp/settings/CommentedTextFileSettingsTest.java
+++ b/src/test/java/com/evilcorp/settings/CommentedTextFileSettingsTest.java
@@ -1,0 +1,25 @@
+package com.evilcorp.settings;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CommentedTextFileSettingsTest {
+
+    @Nested
+    class IgnoresCommentedLines {
+        private final String RAW_SETTINGS = """
+            # waitSeconds=15
+            # waitSeconds=16
+            """;
+
+        @Test
+        public void commentedLinesAreIgnored() {
+            final TextFileSettings settings = new TextFileSettings(new ByteArrayInputStream(RAW_SETTINGS.getBytes()));
+            assertTrue(settings.setting("# waitSeconds").isEmpty());
+        }
+    }
+}

--- a/src/test/java/com/evilcorp/settings/TextFileSettingsTest.java
+++ b/src/test/java/com/evilcorp/settings/TextFileSettingsTest.java
@@ -10,6 +10,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class TextFileSettingsTest {
 
     private final String RAW_SETTINGS = """
+        # comment
+        # waitSeconds=15
+        # waitSeconds=16
         waitSeconds=10
         illegalSetting
         halfDefinedSetting=\s


### PR DESCRIPTION
Lines, starting with # in runmpv.properties are ignored now