### PR TITLE
Take path to logging.properties from logSettings property

### DIFF
--- a/runmpv.properties
+++ b/runmpv.properties
@@ -73,6 +73,25 @@ pipeName=runmpv-mpv-pipe
 #
 # runnerLogFile=%r/runmpv.log
 
+
+# logSettings includes file name, so it is not necessary to name the file
+# "logging.properties". logSettings is taken from command line arguments
+# first. If it's not there, then logging.properties is taken from default
+# location. Default location is <executableDir>/logging.properties . This
+# file is included in binary distribution.
+#
+# If, after reading full config runmpv understands, that logSettings is also
+# defined if runmpv.properties, it restarts logging system, using settings
+# from runmpv.properties. But it only occurs if logSettings is absent in
+# command line arguments.
+#
+# If path in logSettings is relative, then runmpv resolves it relative
+# to <executableDir>.
+#
+# Placeholders like %r, %h, %v ARE NOT SUPPORTED
+#
+#logSettings=logging.properties
+
 # Amount of time after which runmpv decides, that it couldn't launch mpv
 # and it's time to quit. Measured in seconds.
 # Needed, because if you launch video files from hard drive, a lot of time may

--- a/src/main/java/com/evilcorp/StartSingleMpvInstance.java
+++ b/src/main/java/com/evilcorp/StartSingleMpvInstance.java
@@ -148,7 +148,8 @@ public class StartSingleMpvInstance {
 
     public void run() {
         final SoftSettings minDefaultSettings = new ManualSettings(
-            "executableDir", new RunMpvExecutable().path().getParent().toString()
+            "executableDir", new RunMpvExecutable().path().getParent().toString(),
+            "logSettings", "logging.properties"
         );
         final SoftSettings startSettings = new CompositeSettings(
             commandLineSettings,
@@ -158,7 +159,9 @@ public class StartSingleMpvInstance {
         final FsFile videoDir = minSettings.videoDir();
         final FsFile runMpvHomeDir = minSettings.runmpvBinDir();
 
-        initEmergencyLoggingSystem(runMpvHomeDir.path().toString() + "/logging.properties");
+        final String initLogFile = runMpvHomeDir.path()
+            .resolve(minSettings.logSettings().path()).toString();
+        initEmergencyLoggingSystem(initLogFile);
 
         final LocalFsPaths fsPaths = new LocalFsPaths(
             new UserHomeDir(),
@@ -207,6 +210,9 @@ public class StartSingleMpvInstance {
             fsPaths
         );
         this.config = config;
+        final String configLogFile = runMpvHomeDir.path()
+            .resolve(config.logSettings().path()).toString();
+        initEmergencyLoggingSystem(configLogFile);
         if (config.runnerLogFile() != null) {
             rerouteSystemOutStream(config.runnerLogFile());
         }

--- a/src/main/java/com/evilcorp/mpv/MinSettings.java
+++ b/src/main/java/com/evilcorp/mpv/MinSettings.java
@@ -44,4 +44,10 @@ public class MinSettings implements RunmpvMinimalSettings {
             .map(dir -> (FsFile)new ManualFsFile(Path.of(dir)))
             .orElseThrow();
     }
+
+    @Override
+    public FsFile logSettings() {
+        return new ManualFsFile(Path.of(settings.setting("logSettings")
+            .orElseThrow()));
+    }
 }

--- a/src/main/java/com/evilcorp/mpv/RunmpvMinimalSettings.java
+++ b/src/main/java/com/evilcorp/mpv/RunmpvMinimalSettings.java
@@ -37,4 +37,10 @@ public interface RunmpvMinimalSettings {
      * @return directory, where runmpv executable is placed.
      */
     FsFile runmpvBinDir();
+
+    /**
+     * @return File, containing runmpv logging settings.
+     * logging.properties by default.
+     */
+    FsFile logSettings();
 }

--- a/src/main/java/com/evilcorp/settings/ManualRunMpvProperties.java
+++ b/src/main/java/com/evilcorp/settings/ManualRunMpvProperties.java
@@ -1,5 +1,7 @@
 package com.evilcorp.settings;
 
+import com.evilcorp.fs.FsFile;
+
 @SuppressWarnings("MethodCount")
 public class ManualRunMpvProperties implements RunMpvProperties {
     private final Integer waitSeconds;
@@ -11,6 +13,9 @@ public class ManualRunMpvProperties implements RunMpvProperties {
     private final boolean focusAfterOpen;
     private final String video;
     private final String runmpvTmpDir;
+    private final FsFile videoDir;
+    private final FsFile runmpvBinDir;
+    private final FsFile logSettings;
 
     public ManualRunMpvProperties(
         Integer waitSeconds,
@@ -21,7 +26,10 @@ public class ManualRunMpvProperties implements RunMpvProperties {
         String runnerLogFile,
         boolean focusAfterOpen,
         String video,
-        String runmpvTmpDir
+        String runmpvTmpDir,
+        FsFile videoDir,
+        FsFile runmpvBinDir,
+        FsFile logSettings
     ) {
         this.waitSeconds = waitSeconds;
         this.mpvHomeDir = mpvHomeDir;
@@ -32,6 +40,9 @@ public class ManualRunMpvProperties implements RunMpvProperties {
         this.focusAfterOpen = focusAfterOpen;
         this.video = video;
         this.runmpvTmpDir = runmpvTmpDir;
+        this.videoDir = videoDir;
+        this.runmpvBinDir = runmpvBinDir;
+        this.logSettings = logSettings;
     }
 
     @Override
@@ -92,5 +103,20 @@ public class ManualRunMpvProperties implements RunMpvProperties {
     @Override
     public String runmpvTmpDir() {
         return runmpvTmpDir;
+    }
+
+    @Override
+    public FsFile videoDir() {
+        return videoDir;
+    }
+
+    @Override
+    public FsFile runmpvBinDir() {
+        return runmpvBinDir;
+    }
+
+    @Override
+    public FsFile logSettings() {
+        return logSettings;
     }
 }

--- a/src/main/java/com/evilcorp/settings/RunMpvProperties.java
+++ b/src/main/java/com/evilcorp/settings/RunMpvProperties.java
@@ -1,5 +1,7 @@
 package com.evilcorp.settings;
 
+import com.evilcorp.mpv.RunmpvMinimalSettings;
+
 /**
  * Settings for runmpv.
  *
@@ -9,7 +11,7 @@ package com.evilcorp.settings;
  * Code completion works and all settings are typed.
  */
 @SuppressWarnings("MethodCount")
-public interface RunMpvProperties {
+public interface RunMpvProperties extends RunmpvMinimalSettings {
     /**
      * Number of seconds to wait until mpv executable starts,
      * before quitting with error.

--- a/src/main/java/com/evilcorp/settings/RunMpvPropertiesFromSettings.java
+++ b/src/main/java/com/evilcorp/settings/RunMpvPropertiesFromSettings.java
@@ -110,4 +110,9 @@ public class RunMpvPropertiesFromSettings implements RunMpvProperties, RunmpvMin
     public FsFile runmpvBinDir() {
         return minSettings.runmpvBinDir();
     }
+
+    @Override
+    public FsFile logSettings() {
+        return minSettings.logSettings();
+    }
 }


### PR DESCRIPTION
If path in logSettings is relative, then runmpv resolves it relative
to <executableDir>.

logSettings includes file name, so it is not necessary to name the file
"logging.properties". logSettings is taken from command line arguments
first. If it's not there, then logging.properties is taken from default
location. Default location is <executableDir>/logging.properties . This
file is included in binary distribution.

If, after reading full config runmpv understands, that logSettings is also
defined if runmpv.properties, it restarts logging system, using settings
from runmpv.properties. But it only occurs if logSettings is absent in
command line arguments.